### PR TITLE
MakeFromAST in interpreter to share ASTs

### DIFF
--- a/src/lua.mli
+++ b/src/lua.mli
@@ -328,5 +328,5 @@ module type INTERP = sig
   val mk        : unit -> state
 end
 module MakeInterp (MakeParser : Parser.MAKER) (I : EVALUATOR)
-    : INTERP with module Value = I.Value
+    : INTERP with module Value = I.Value and module Ast = I.Ast
 module Run (I : INTERP) : sig end  (* runs interpreter on Sys.argv *)

--- a/src/luabaselib.mli
+++ b/src/luabaselib.mli
@@ -5,4 +5,4 @@ module Add (MakeParser : Luaparser.MAKER) (I : Luainterp.S) : sig
   val dostring  : ?file:string -> state -> string -> value list
   val dofile    : state -> string -> value list
   val mk        : unit -> state  (* builds state and runs startup code *)
-end with module Value = I.Value
+end with module Value = I.Value and module Ast = I.Ast

--- a/src/luainterp.mli
+++ b/src/luainterp.mli
@@ -29,3 +29,13 @@ end
 module Make (T : Luavalue.USERDATA)
             (L : Lualib.USERCODE with type 'a userdata' = 'a T.t) :
     S with type 'a Value.userdata'  = 'a T.t
+
+(** [MakeFromAST (A) (L)] makes an interpreter module from the AST
+    module [A] and the usercode module (L).
+
+    Preferable to {!Make} when you have multiple interpreters and want
+    to share the ASTs and values between them. *)
+module MakeFromAST
+        (A : Luaast.S)
+        (L : Lualib.USERCODE with type 'a userdata' = 'a A.Value.userdata') :
+    S with module Value = A.Value and module Ast = A


### PR DESCRIPTION
When sharing an AST (or a Value) between interpreters, the Luainterp.Make has insufficient type and module equalities; OCaml will rightly complain that they can't be shared with errors like:

```text
This expression has type
  MlFront_Thunk.ThunkLuaScript.IAnalyze.Ast.chunk list
but an expression was expected of type
  Luaast.Make(MlFront_Thunk.ThunkLuaScript.Value).chunk list
Type MlFront_Thunk.ThunkLuaScript.IAnalyze.Ast.chunk is not compatible with type
  Luaast.Make(MlFront_Thunk.ThunkLuaScript.Value).chunk
```

Instead:

+ introduce a new functor `MakeFromAST` which has full module equivalence
+ The old `Make` functor is defined in terms of the new `MakeFromAST`
+ add module equality to `Luabaselib.Add` for the `Ast` functor parameter (ditto for `Lua.MakeInterp`)

Now we can do something like the following (note: `Luainterp.MakeFromAST` instead of `Lua.MakeEval`):

```ocaml
module Value = Luavalue.Make (T)
module Ast = Luaast.Make (Value)

module IAnalyze =
  Lua.MakeInterp
    (Lua.Parser.MakeStandard)
    (Luainterp.MakeFromAST (Ast) (CAnalyze))

module IBuild =
  Lua.MakeInterp
    (Lua.Parser.MakeStandard)
    (Luainterp.MakeFromAST (Ast) (CBuild))
```