### PR TITLE
Update Menhir positions

### DIFF
--- a/src/lua.mli
+++ b/src/lua.mli
@@ -107,6 +107,7 @@ module Parser : sig
     sig
       type chunk
       val chunks : (Lexing.lexbuf  -> Luaparser_tokens.token) -> Lexing.lexbuf -> chunk list
+      exception Error
     end
   module type MAKER = functor (Ast : AST) -> S with type chunk = Ast.chunk
   module MakeStandard : MAKER

--- a/src/luabaselib.ml
+++ b/src/luabaselib.ml
@@ -13,7 +13,7 @@ let do_lexbuf ~sourcename:filename g buf =
     | [] -> [I.Value.LuaValueBase.String "executed without errors"]
     | answers -> answers
   with
-  | Parsing.Parse_error ->
+  | Parser.Error ->
     let file, line, _ = Luasrcmap.last map in
     let errmsg = Printf.sprintf "%s: Syntax error on line %d" file line in
     failwith errmsg

--- a/src/luaparser.ml
+++ b/src/luaparser.ml
@@ -1,6 +1,7 @@
 module type S = sig
   type chunk
   val chunks : (Lexing.lexbuf  -> Luaparser_tokens.token) -> Lexing.lexbuf -> chunk list
+  exception Error
 end
 
 module type MAKER = functor (Ast : Luaast.S) -> S with type chunk = Ast.chunk
@@ -11,4 +12,5 @@ module MakeStandard (Ast : Luaast.S) = struct
   module P = Luaparser_impl.Make(Ast)
 
   let chunks = P.chunks
+  exception Error = P.Error
 end

--- a/src/luaparser.mli
+++ b/src/luaparser.mli
@@ -1,6 +1,7 @@
 module type S = sig
   type chunk
   val chunks : (Lexing.lexbuf  -> Luaparser_tokens.token) -> Lexing.lexbuf -> chunk list
+  exception Error
 end
 module type MAKER = functor (Ast : Luaast.S) -> S with type chunk = Ast.chunk
 module MakeStandard : MAKER

--- a/src/luaparser_impl.mly
+++ b/src/luaparser_impl.mly
@@ -16,7 +16,7 @@ chunklist : /* empty */        { [] }
           | chunklist DEBUG_PRAGMA { Ast.Debug ($2 <> 0) :: $1 }
 	  ;
 
-function_     : FUNCTION funcname body  { $2 $3 (Parsing.symbol_start()) };
+function_     : FUNCTION funcname body  { $2 $3 ($symbolstartofs) };
 
 funcname  : var             { fun (args, ss) w -> Ast.Fundef (w, $1, args, ss) }
 	  | varexp COLON NAME { fun (args, ss) w -> Ast.Methdef (w, $1, $3, args, ss) }
@@ -30,7 +30,7 @@ statlist : /* empty */         { [] }
 
 sc	 : /* empty */ { () } | SEMI { () } ;
 
-stat   : stat_ { Ast.Stmt' (Parsing.symbol_start (), $1) }
+stat   : stat_ { Ast.Stmt' ($symbolstartofs, $1) }
 stat_  : IF expr1 THEN block elsepart END { let (a, e) = $5 in Ast.If ($2, $4, a, e) }
   /*
        | CASE expr1 OF case_body END


### PR DESCRIPTION
Per https://pauillac.inria.fr/~fpottier/menhir/manual.html:

> OCaml’s standard library module Parsing is deprecated. The functions that it offers can be called, but will return dummy positions.

In particular, in luaparser_impl.mly:

```
   stat   : stat_ { Ast.Stmt' (Parsing.symbol_start (), $1) }
```

can have `Parsing.symbol_start () = -1`.

That makes the following search assertion in luasrcmap.ml fail:

```ocaml
let search x array length cmp =
   (* ... *)
   assert (0 <= right && right < Array.length array)
   (* ==> search: x=-1 length=90 left=0 right=-1 *)
```

Chapter 7 (Positions) of the Menhir guide has the translations from ocamlyacc to Menhir in Figure 15: "Translating position-related incantations from ocamlyacc to Menhir". The relevant one is:

```text
Parsing.symbol_start() --> $symbolstartofs
```

---

Also `Parsing.Parse_error` is not raised unless `--fixed-exception` is enabled in Menhir. Instead Menhir raises an "Error" exception defined in the parser. So added the Error exception to the parser interface, and caught that Error exception rather than Parsing.Parse_error.