### PR TITLE
Fix V.record to (k,v) not (v,v)

### DIFF
--- a/src/luavalue.ml
+++ b/src/luavalue.ml
@@ -358,7 +358,7 @@ let table = { embed = (fun x -> Table x)
 let projectRecord ty v = match v with
 | Table t ->
     let rec addpairs (k, v) =
-      (string.project v, ty.project v) ::
+      (string.project k, ty.project v) ::
       try addpairs (Table.next t k) with Not_found -> [] in
     (try addpairs (Table.first t) with Not_found -> [])
 | _ -> raise (Projection (v, "table (as record)"))


### PR DESCRIPTION
Per the Lua ml docs:

> A common case is to use a table as a record, with string keys and homogenous values.

> `val record : 'a map -> (string * 'a) list map`

The [projectRecord] function silently ignores the keys.

The following [record] function uses [projectRecord] and also ignores the keys.